### PR TITLE
SPII-73: Change default thruster config to 'T'

### DIFF
--- a/vrx_gz/src/vrx_gz/model.py
+++ b/vrx_gz/src/vrx_gz/model.py
@@ -234,7 +234,7 @@ class Model:
         xacro_command.append(f'namespace:={self.model_name}')
         xacro_command.append(f'locked:=true')
         xacro_command.append(f'vrx_sensors_enabled:=true')
-        xacro_command.append(f'thruster_config:=H')
+        xacro_command.append(f'thruster_config:=T')
         xacro_process = subprocess.Popen(xacro_command,
                                          stdout=subprocess.PIPE,
                                          stderr=subprocess.PIPE)


### PR DESCRIPTION
https://rekise.youtrack.cloud/agiles/141-8/142-8?issue=SPII-73: 
Change the default thruster config from 'H' to 'T' type.